### PR TITLE
Sam enable multi arch build

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -29,6 +29,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract branch name
+        id: extract_branch
+        run: |
+          ref=${GITHUB_REF#refs/heads/}
+          # Sanitize branch name for Docker tag (lowercase, no slashes)
+          safe_ref=$(echo "$ref" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9._-' '-')
+          echo "branch=$safe_ref" >> $GITHUB_OUTPUT
+
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v5
         with:
@@ -38,4 +46,5 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.extract_branch.outputs.branch }}
             ghcr.io/${{ github.repository }}:${{ github.sha }} 

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -1,0 +1,41 @@
+name: Build and Push Multi-Arch Docker Image
+
+on:
+  push:
+    # Triggers on push to any branch
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }} 

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -2,7 +2,8 @@ name: Build and Push Multi-Arch Docker Image
 
 on:
   push:
-    # Triggers on push to any branch
+    branches:
+      - master
 
 jobs:
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
+ARG TARGETPLATFORM  # auto-filled by Buildx
 FROM eclipse-temurin:24-jdk
 
-ENV CHAMBER_VERSION=v2.2.0
+ENV CHAMBER_VERSION=v3.0.0
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl
+# Choose the right Chamber binary for the platform -----------------------------
+ARG TARGETPLATFORM
+RUN bash -c 'set -eux; \
+    apt-get update -y; \
+    apt-get install -y --no-install-recommends curl ca-certificates; \
+    arch="${TARGETPLATFORM##*/}"; \
+    case "$arch" in \
+        amd64|arm64) CH_ARCH="$arch" ;; \
+        *) echo "Unsupported arch: $arch" && exit 1 ;; \
+    esac; \
+    curl -fsSL -o /usr/local/bin/chamber "https://github.com/segmentio/chamber/releases/download/${CHAMBER_VERSION}/chamber-${CHAMBER_VERSION}-linux-${CH_ARCH}"; \
+    chmod 755 /usr/local/bin/chamber; \
+    apt-get clean; rm -rf /var/lib/apt/lists/*'
 
-RUN curl -o /usr/local/bin/chamber -Ls https://github.com/segmentio/chamber/releases/download/${CHAMBER_VERSION}/chamber-${CHAMBER_VERSION}-linux-amd64
-
-RUN chmod 700 /usr/local/bin/chamber
 


### PR DESCRIPTION
- CI/CD: A new GitHub Actions workflow has been added to build multi-architecture Docker images. This workflow is triggered only on pushes to the master branch.
- Docker: The Dockerfile has been updated to support multi-architecture builds and the image tagging has been updated.
- Java: The Java version used in the Docker image has been upgraded multiple times, from Java 17 to 21, and finally to Java 24.